### PR TITLE
Implement Nop FrameGen Writer

### DIFF
--- a/gsv_test.go
+++ b/gsv_test.go
@@ -103,9 +103,13 @@ func Benchmark_sleep_sort(b *testing.B)     { benchmarkSort("sleep", b) }
 func Benchmark_stooge_sort(b *testing.B)    { benchmarkSort("stooge", b) }
 func Benchmark_quick_sort(b *testing.B)     { benchmarkSort("quick", b) }
 
+// WriteNop is a writer for FrameGen that does nothing.
+// Ensures we only benchmark alogrithms.
+func WriteNop(_ []int) {}
+
 func benchmarkSort(sort string, b *testing.B) {
 	arr := randomArray(Count, Max)
-	frameGen := FrameGen(WriteStdout)
+	frameGen := FrameGen(WriteNop)
 	if sort, found := sorterMap[sort]; found {
 		for n := 0; n < b.N; n++ {
 			sort(arr, frameGen)


### PR DESCRIPTION
Using WriteStdout skews the benchmark stats, better to use a FrameGen writer that does nothing. Here's the benchmark comparisons using WriteStdout and WriteNop using [benchmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp):

```
benchmark                      old ns/op      new ns/op      delta
Benchmark_bogo_sort-8          521            11.0           -97.89%
Benchmark_bubble_sort-8        42210          200            -99.53%
Benchmark_cocktail_sort-8      504            12.3           -97.56%
Benchmark_comb_sort-8          17019          90.5           -99.47%
Benchmark_counting_sort-8      5276           70.9           -98.66%
Benchmark_gnome_sort-8         4249           24.1           -99.43%
Benchmark_insertion_sort-8     4800           25.2           -99.47%
Benchmark_oddEven_sort-8       4741           26.2           -99.45%
Benchmark_sleep_sort-8         2001200825     2001174351     -0.00%
Benchmark_stooge_sort-8        83621          650            -99.22%
Benchmark_quick_sort-8         4741           83.3           -98.24%
```